### PR TITLE
Added new keys  entry_type, git_version, error_code

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,9 +94,9 @@ Insert structured log data into a Redis list for later analysis or auditing.
 - **Domain**: Domain name.
 - **System**: System type.
 - **Session ID**: Session identifier.
-- **Transaction ID**: (Optional) Transaction identifier.
+- **Entry Type**: (Optional) Entry type for log classification.
+- **Error Code**: (Optional) Error code associated with the log entry.
 - **Message Context**: (Optional) Additional details as a JSON object or string.
-- **Is Note?**: (Optional) Mark entry as a note.
 - **Property Key**: (Optional) Additional property key.
 - **Property Value**: (Optional) Additional property value.
 

--- a/server_connect/redis_tools.hjson
+++ b/server_connect/redis_tools.hjson
@@ -278,13 +278,13 @@
             "help": "Session ID"
           },
           {
-            "name": "transaction_id",
-            "optionName": "transaction_id",
-            "title": "Transaction ID",
+            "name": "entry_type",
+            "optionName": "entry_type",
+            "title": "Entry Type",
             "type": "text",
             "required": false,
             "serverDataBindings": true,
-            "help": "Transaction ID (optional)"
+            "help": "Entry Type"
           },
           {
             "name": "context",
@@ -295,15 +295,6 @@
             "defaultValue": "",
             "serverDataBindings": true,
             "help": "Additional details as a JSON object"
-          },
-          {
-            "name": "is_note",
-            "optionName": "is_note",
-            "title": "Is Note?",
-            "type": "text",
-            "defaultValue": "",
-            "serverDataBindings": true,
-            "help": "Entry to be considered as note."
           },
           {
             "name": "p_key",

--- a/server_connect/redis_tools.hjson
+++ b/server_connect/redis_tools.hjson
@@ -232,8 +232,8 @@
             "help": "Event Description"
           },
           {
-            "name": "type",
-            "optionName": "type",
+            "name": "e_type",
+            "optionName": "e_type",
             "title": "Type",
             "type": "text",
             "required": true,

--- a/server_connect/redis_tools.hjson
+++ b/server_connect/redis_tools.hjson
@@ -187,6 +187,15 @@
         "group": "Log Data",
         "variables": [
           {
+            "name": "error_code",
+            "optionName": "error_code",
+            "title": "Error Code",
+            "type": "text",
+            "required": false,
+            "serverDataBindings": true,
+            "help": "Error Code"
+          },
+          {
             "name": "timestamp",
             "optionName": "timestamp",
             "title": "Timestamp",
@@ -248,6 +257,7 @@
             "required": true,
             "defaultValue": "",
             "serverDataBindings": true,
+            "allowEdit": true,
             "help": "The log message"
           },
           {

--- a/server_connect/redis_tools.js
+++ b/server_connect/redis_tools.js
@@ -30,107 +30,207 @@ exports.redis_query = async function (options) {
     }
     const output = await redis.get(key);
     if (typeof output === 'string') {
-      try {
-        const parsedOutput = JSON.parse(output);
-        return parsedOutput;
-      } catch (parseErr) {
-        // Not JSON, return as string
-        return output;
-      }
+      const parsedOutput = JSON.parse(output);
+      return parsedOutput;
     }
     return output;
   } catch (error) {
-    console.error('Redis query error:', error);
+    console.log('Redis query error:', error);
     throw error;
   }
 };
 
+
 exports.redis_ping = async function (options) {
+  const timeout = this.parse(options.timeout) || 5000; // Default timeout: 5 seconds
+  if (!redis) {
+    throw new Error('Redis client is not available.');
+  }
+  const pingPromise = redis.ping();
   try {
-    const timeout = this.parse(options.timeout) || 5000; // Default timeout: 5 seconds
-    if (!redis) {
-      throw new Error('Redis client is not available.');
-    }
-    const pingPromise = redis.ping();
     // Wait for the ping operation or timeout, whichever occurs first
     const output = await Promise.race([
       pingPromise,
       new Promise((_, reject) => setTimeout(() => reject(new Error('Redis ping operation timed out.')), timeout))
     ]);
+
     return output;
   } catch (error) {
-    console.error('Redis ping error:', error);
     throw error;
   }
 };
 
 exports.redis_insert = async function (options) {
-  try {
-    if (!redis) {
-      throw new Error('Redis client is not available.');
+  if (!redis) {
+    throw new Error('Redis client is not available.');
+  }
+  const key = this.parse(options.key)
+  const data = this.parse(options.data)
+  if (!key || !data) {
+    throw new Error('Invalid key or data provided.');
+  }
+  await redis.set(key, JSON.stringify(data), (error, result) => {
+    if (error) {
+      console.error('Error setting JSON array data:', error);
     }
-    const key = this.parse(options.key);
-    const data = this.parse(options.data);
-    if (!key || typeof data === 'undefined') {
-      throw new Error('Invalid key or data provided.');
-    }
-    await redis.set(key, JSON.stringify(data));
-    return { success: true };
-  } catch (error) {
-    console.error('Redis insert error:', error);
-    throw error;
+  });
+}
+
+/**
+ * Masks sensitive data by keeping only last N characters
+ * @param {string} input The input string to mask
+ * @returns {string} The masked string
+ */
+const maskData = (input) => {
+  const inputString = String(input);
+  const length = inputString.length;
+
+  if (length <= 3) {
+    return '**' + inputString.slice(-1);
+  } else if (length <= 6) {
+    return '**' + inputString.slice(-2);
+  } else if (length <= 9) {
+    return '**' + inputString.slice(-3);
+  } else {
+    return '**' + inputString.slice(-4);
   }
 };
 
+/**
+ * Loads and validates PII configuration from pii-fields.json
+ * @returns {object|null} The validated PII config or null if invalid
+ */
+const loadPiiConfig = async () => {
+  try {
+    const config = require('../../../app/config/pii-fields.json');
+    // Validate required properties
+    const hasRedactedFields = Array.isArray(config.redacted_fields) && config.redacted_fields.length > 0;
+    const hasMaskedFields = Array.isArray(config.masked_fields) && config.masked_fields.length > 0;
+
+    if (!hasRedactedFields || !hasMaskedFields) {
+      return null;
+    }
+
+    return config;
+  } catch (error) {
+    console.error('Error loading PII configuration:', error);
+    return null;
+  }
+};
+
+/**
+ * Safely parses an object by stringifying and then parsing it.
+ * If the input is not an object or parsing fails, it returns a default structure.
+ *
+ * @param {any} input The input value (from options or context).
+ * @returns {object} The safely parsed object or a default object structure.
+ */
+const safeParseObject = (input) => {
+  const parsedInput = input;
+
+  if (typeof parsedInput === 'object' && parsedInput !== null) {
+
+    try {
+      return JSON.parse(JSON.stringify(parsedInput));
+    } catch (error) {
+      console.error('Error during safe object parsing for logging:', error);
+      return { data: parsedInput };
+    }
+  }
+
+  return { data: parsedInput };
+};
+
+/**
+ * Recursively sanitizes context data based on PII configuration
+ * @param {any} data The data to sanitize
+ * @param {object} piiConfig The PII configuration object
+ * @returns {any} The sanitized data
+ */
+const sanitizeContext = (data, piiConfig) => {
+  if (!piiConfig) {
+    return {};
+  }
+
+  if (typeof data !== 'object' || data === null) {
+    return data;
+  }
+
+  if (Array.isArray(data)) {
+    return data.map(item => sanitizeContext(item, piiConfig));
+  }
+
+  const sanitized = { ...data };
+
+  for (const key in sanitized) {
+    if (sanitized.hasOwnProperty(key)) {
+
+      // Check if value should be redacted
+      if (piiConfig.redacted_fields.includes(key)) {
+        sanitized[key] = '[REDACTED]';
+        continue;
+      }
+
+      // Check if value should be masked
+      if (piiConfig.masked_fields.includes(key)) {
+        sanitized[key] = maskData(sanitized[key]);
+        continue;
+      }
+
+      // Recursively sanitize nested objects and arrays
+      if (typeof sanitized[key] === 'object' && sanitized[key] !== null) {
+        sanitized[key] = sanitizeContext(sanitized[key], piiConfig);
+      }
+    }
+  }
+
+  return sanitized;
+};
+
+const toStringOrEmpty = (value) => {
+  const parsedValue = value;
+  return parsedValue !== undefined && parsedValue !== null
+    ? String(parsedValue)
+    : "";
+};
+
+/**
+ * ASTRA-4927: Take proper snapshot of object data for aux and, if provided, p_value
+ */
 exports.redis_log_insert = async function (options) {
-  try {
-    if (!redis) {
-      throw new Error('Redis client is not available.');
-    }
-    const logData = {
-      ts: this.parse(options.timestamp),
-      level: this.parse(options.log_level),
-      e_event: this.parse(options.event),
-      e_id: this.parse(options.id),
-      e_type: this.parse(options.type),
-      uid: this.parse(options.user_id),
-      msg: this.parse(options.message),
-      domain: this.parse(options.domain),
-      sys: this.parse(options.system),
-      sess_id: this.parse(options.session_id),
-      t_id: this.parse(options.transaction_id) ? this.parse(options.transaction_id) : "",
-      aux: typeof this.parse(options.context) === 'object' ? this.parse(options.context) : { data: this.parse(options.context) },
-      is_note: this.parse(options.is_note) ? this.parse(options.is_note) : "",
-      p_key: this.parse(options.p_key) ? this.parse(options.p_key) : "",
-      p_value: this.parse(options.p_value) ? String(this.parse(options.p_value)) : ""
-    };
-    const key = this.parse(options.key);
-    if (!key) {
-      throw new Error('Invalid key provided for log insert.');
-    }
-    const jsonString = JSON.stringify(logData);
-    // Push the JSON data onto a Redis list
-    await redis.rpush(key, jsonString);
-    return { success: true };
-  } catch (error) {
-    console.error('Redis log insert error:', error);
-    throw error;
+  if (!redis) {
+    throw new Error('Redis client is not available.');
   }
-};
 
-exports.redis_delete = async function (options) {
-  try {
-    if (!redis) {
-      throw new Error('Redis client is not available.');
+  const utcDate = new Date().toISOString();
+
+  // Load and validate PII configuration
+  const piiConfig = await loadPiiConfig();
+
+  const p_value = this.parse(options.p_value);
+  const logData = {
+    ts: utcDate,
+    level: toStringOrEmpty(this.parse(options.log_level)),
+    e_event: toStringOrEmpty(this.parse(options.event)),
+    e_id: toStringOrEmpty(this.parse(options.id)),
+    e_type: toStringOrEmpty(this.parse(options.e_type)),
+    uid: Number(this.parse(options.user_id)),
+    msg: toStringOrEmpty(this.parse(options.message)),
+    domain: toStringOrEmpty(this.parse(options.domain)),
+    sys: toStringOrEmpty(this.parse(options.system)),
+    sess_id: toStringOrEmpty(this.parse(options.session_id)),
+    entry_type: toStringOrEmpty(this.parse(options.entry_type)),
+    p_key: toStringOrEmpty(this.parse(options.p_key)),
+    aux: sanitizeContext(safeParseObject(this.parse(options.context)), piiConfig),
+    p_value: typeof p_value === 'object' ? sanitizeContext(safeParseObject(p_value), piiConfig) : toStringOrEmpty(p_value)
+  };
+
+  const jsonString = JSON.stringify(logData);
+
+  // Push the JSON data onto a Redis list
+  await redis.rpush(this.parse(process.env.LOG_REDIS_KEY), jsonString, (error, result) => {
+    if (error) {
+      console.error('Error pushing data to Redis list:', error);
     }
-    const key = this.parse(options.key);
-    if (!key) {
-      throw new Error('Invalid key provided.');
-    }
-    const result = await redis.del(key);
-    return { success: true, deleted: result };
-  } catch (error) {
-    console.error('Redis delete error:', error);
-    throw error;
-  }
+  });
 };

--- a/server_connect/redis_tools.js
+++ b/server_connect/redis_tools.js
@@ -215,6 +215,8 @@ exports.redis_log_insert = async function (options) {
     e_id: toStringOrEmpty(this.parse(options.id)),
     e_type: toStringOrEmpty(this.parse(options.e_type)),
     uid: Number(this.parse(options.user_id)),
+    error_code: toStringOrEmpty(this.parse(options.error_code)),
+    git_version: process.env.LOG_GIT_VERSION || '',
     msg: toStringOrEmpty(this.parse(options.message)),
     domain: toStringOrEmpty(this.parse(options.domain)),
     sys: toStringOrEmpty(this.parse(options.system)),


### PR DESCRIPTION
# Redis Tools - Log Insert Parameters Update

## Summary

Updated the `redis_log_insert` function to improve log entry structure and remove deprecated parameters.

## Changes Made

### Added
- **`entry_type`** - New field for classifying log entries by type (optional). This allows for better categorization and filtering of log entries based on their purpose or classification.
-  **`error_code`** - Optional field for associating error codes with log entries.
- **`git_version`** - git_version with log entries.

### Removed
- **`transaction_id`** - Removed deprecated transaction identifier parameter. This functionality can be tracked through other means if needed.
- **`is_note`** - Removed the note flag parameter. Entry classification is now handled through the new `entry_type` field instead.

## Files Modified

- `server_connect/redis_tools.js` - Updated `redis_log_insert` function to use new log schema
- `server_connect/redis_tools.hjson` - Updated configuration to reflect new parameters
- `README.md` - Updated documentation with new parameters and removed deprecated ones

The log entry object now contains:
```json
{
  "ts": "ISO timestamp",
  "level": "log level",
  "e_event": "event description",
  "e_id": "event id",
  "e_type": "event type",
  "uid": "user id",
  "error_code": "error code",
  "git_version": "git version",
  "msg": "message",
  "domain": "domain",
  "sys": "system",
  "sess_id": "session id",
  "entry_type": "entry_type",
  "p_key": "property key",
  "aux": "context object",
  "p_value": "property value"
}